### PR TITLE
fix(playground): always set language to trigger the tree-sitter language onChange event

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -119,6 +119,7 @@ comments: >
 </script>
 <script>
   let select = document.getElementById('language-select')
-  select.nodeValue = 'yaml'
+  select.value = 'yaml'
+  select.dispatchEvent(new Event('change'))
 </script>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -117,3 +117,8 @@ comments: >
   src="https://code.jquery.com/jquery-3.3.1.min.js"
   crossorigin="anonymous">
 </script>
+<script>
+  let select = document.getElementById('language-select')
+  select.nodeValue = 'yaml'
+</script>
+


### PR DESCRIPTION
Closes #8

set default language to `yaml` by `js`, because use html set the default select value  does't trigger  the `tree-sitter.js` onChange event