### PR TITLE
feat(queries): add highlight queries

### DIFF
--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -1,0 +1,29 @@
+;; keys
+(block_mapping_pair
+ key: (flow_node [(double_quote_scalar) (single_quote_scalar)] @variable))
+(block_mapping_pair
+ key: (flow_node (plain_scalar (string_scalar) @variable)))
+
+;; keys within inline {} blocks
+(flow_mapping
+ (_ key: (flow_node [(double_quote_scalar) (single_quote_scalar)] @variable)))
+(flow_mapping
+ (_ key: (flow_node (plain_scalar (string_scalar) @variable))))
+
+["[" "]" "{" "}"] @punctuation.bracket
+["," "-" ":" "?" ">" "|"] @punctuation.delimiter
+["*" "&" "---" "..."] @punctuation.special
+
+[(null_scalar) (boolean_scalar)] @constant.builtin
+[(integer_scalar) (float_scalar)] @number
+[(double_quote_scalar) (single_quote_scalar) (block_scalar)] @string
+(escape_sequence) @escape
+
+(comment) @comment
+[(anchor_name) (alias_name)] @function
+(yaml_directive) @type
+
+(tag) @type
+(tag_handle) @type
+(tag_prefix) @string
+(tag_directive) @property


### PR DESCRIPTION
Adds a set of queries for syntax highlighting yaml, similar to other tree-sitter grammar projects.

This is the same queries from my PR against Emacs' tree-sitter-langs project: https://github.com/emacs-tree-sitter/tree-sitter-langs/pull/134

## Screenshot

Here's how syntax highlighting turns out in Emacs, using the doom-vibrant theme:

![Screen-Shot-2022-11-24-01-06-01 42](https://user-images.githubusercontent.com/39563/203683111-5afdf15e-d6e4-41f1-adf9-e23b3a3efd67.png)