### PR TITLE
tree-sitter generate

### DIFF
--- a/src/parser.c
+++ b/src/parser.c
@@ -311,7 +311,7 @@ enum {
   aux_sym__br_mtl_sqt_ctn_repeat1 = 292,
 };
 
-static const char *ts_symbol_names[] = {
+static const char * const ts_symbol_names[] = {
   [ts_builtin_sym_end] = "end",
   [sym__eof] = "_eof",
   [sym__s_dir_yml_bgn] = "_s_dir_yml_bgn",
@@ -607,7 +607,7 @@ static const char *ts_symbol_names[] = {
   [aux_sym__br_mtl_sqt_ctn_repeat1] = "_br_mtl_sqt_ctn_repeat1",
 };
 
-static TSSymbol ts_symbol_map[] = {
+static const TSSymbol ts_symbol_map[] = {
   [ts_builtin_sym_end] = ts_builtin_sym_end,
   [sym__eof] = sym__eof,
   [sym__s_dir_yml_bgn] = sym__s_dir_yml_bgn,
@@ -2083,7 +2083,7 @@ enum {
   field_value = 2,
 };
 
-static const char *ts_field_names[] = {
+static const char * const ts_field_names[] = {
   [0] = NULL,
   [field_key] = "key",
   [field_value] = "value",
@@ -2125,7 +2125,7 @@ static const TSFieldMapEntry ts_field_map_entries[] = {
     {field_value, 1, .inherited = true},
 };
 
-static TSSymbol ts_alias_sequences[PRODUCTION_ID_COUNT][MAX_ALIAS_SEQUENCE_LENGTH] = {
+static const TSSymbol ts_alias_sequences[PRODUCTION_ID_COUNT][MAX_ALIAS_SEQUENCE_LENGTH] = {
   [0] = {0},
   [6] = {
     [0] = sym__r_flw_exp_par,
@@ -2138,7 +2138,7 @@ static TSSymbol ts_alias_sequences[PRODUCTION_ID_COUNT][MAX_ALIAS_SEQUENCE_LENGT
   },
 };
 
-static uint16_t ts_non_terminal_alias_map[] = {
+static const uint16_t ts_non_terminal_alias_map[] = {
   sym__bgn_imp_doc, 2,
     sym__bgn_imp_doc,
     sym__drs_doc_end,
@@ -2194,7 +2194,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
   }
 }
 
-static TSLexMode ts_lex_modes[STATE_COUNT] = {
+static const TSLexMode ts_lex_modes[STATE_COUNT] = {
   [0] = {.lex_state = 0, .external_lex_state = 1},
   [1] = {.lex_state = 0, .external_lex_state = 2},
   [2] = {.lex_state = 0, .external_lex_state = 3},
@@ -3884,7 +3884,7 @@ enum {
   ts_external_token_comment = 104,
 };
 
-static TSSymbol ts_external_scanner_symbol_map[EXTERNAL_TOKEN_COUNT] = {
+static const TSSymbol ts_external_scanner_symbol_map[EXTERNAL_TOKEN_COUNT] = {
   [ts_external_token__eof] = sym__eof,
   [ts_external_token__s_dir_yml_bgn] = sym__s_dir_yml_bgn,
   [ts_external_token__r_dir_yml_ver] = sym__r_dir_yml_ver,
@@ -3992,7 +3992,7 @@ static TSSymbol ts_external_scanner_symbol_map[EXTERNAL_TOKEN_COUNT] = {
   [ts_external_token_comment] = sym_comment,
 };
 
-static bool ts_external_scanner_states[110][EXTERNAL_TOKEN_COUNT] = {
+static const bool ts_external_scanner_states[110][EXTERNAL_TOKEN_COUNT] = {
   [1] = {
     [ts_external_token__eof] = true,
     [ts_external_token__s_dir_yml_bgn] = true,
@@ -6255,7 +6255,7 @@ static bool ts_external_scanner_states[110][EXTERNAL_TOKEN_COUNT] = {
   },
 };
 
-static uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
+static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
   [0] = {
     [ts_builtin_sym_end] = ACTIONS(1),
     [sym__eof] = ACTIONS(1),
@@ -14181,7 +14181,7 @@ static uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
   },
 };
 
-static uint16_t ts_small_parse_table[] = {
+static const uint16_t ts_small_parse_table[] = {
   [0] = 37,
     ACTIONS(3), 1,
       sym_comment,
@@ -35923,7 +35923,7 @@ static uint16_t ts_small_parse_table[] = {
       sym__r_acr_ctn,
 };
 
-static uint32_t ts_small_parse_table_map[] = {
+static const uint32_t ts_small_parse_table_map[] = {
   [SMALL_STATE(88)] = 0,
   [SMALL_STATE(89)] = 139,
   [SMALL_STATE(90)] = 278,
@@ -37417,7 +37417,7 @@ static uint32_t ts_small_parse_table_map[] = {
   [SMALL_STATE(1578)] = 27583,
 };
 
-static TSParseActionEntry ts_parse_actions[] = {
+static const TSParseActionEntry ts_parse_actions[] = {
   [0] = {.entry = {.count = 0, .reusable = false}},
   [1] = {.entry = {.count = 1, .reusable = false}}, RECOVER(),
   [3] = {.entry = {.count = 1, .reusable = true}}, SHIFT_EXTRA(),
@@ -38709,7 +38709,7 @@ void tree_sitter_yaml_external_scanner_deserialize(void *, const char *, unsigne
 #endif
 
 extern const TSLanguage *tree_sitter_yaml(void) {
-  static TSLanguage language = {
+  static const TSLanguage language = {
     .version = LANGUAGE_VERSION,
     .symbol_count = SYMBOL_COUNT,
     .alias_count = ALIAS_COUNT,
@@ -38720,22 +38720,22 @@ extern const TSLanguage *tree_sitter_yaml(void) {
     .production_id_count = PRODUCTION_ID_COUNT,
     .field_count = FIELD_COUNT,
     .max_alias_sequence_length = MAX_ALIAS_SEQUENCE_LENGTH,
-    .parse_table = (const uint16_t *)ts_parse_table,
-    .small_parse_table = (const uint16_t *)ts_small_parse_table,
-    .small_parse_table_map = (const uint32_t *)ts_small_parse_table_map,
+    .parse_table = &ts_parse_table[0][0],
+    .small_parse_table = ts_small_parse_table,
+    .small_parse_table_map = ts_small_parse_table_map,
     .parse_actions = ts_parse_actions,
     .symbol_names = ts_symbol_names,
     .field_names = ts_field_names,
-    .field_map_slices = (const TSFieldMapSlice *)ts_field_map_slices,
-    .field_map_entries = (const TSFieldMapEntry *)ts_field_map_entries,
+    .field_map_slices = ts_field_map_slices,
+    .field_map_entries = ts_field_map_entries,
     .symbol_metadata = ts_symbol_metadata,
     .public_symbol_map = ts_symbol_map,
     .alias_map = ts_non_terminal_alias_map,
-    .alias_sequences = (const TSSymbol *)ts_alias_sequences,
+    .alias_sequences = &ts_alias_sequences[0][0],
     .lex_modes = ts_lex_modes,
     .lex_fn = ts_lex,
     .external_scanner = {
-      (const bool *)ts_external_scanner_states,
+      &ts_external_scanner_states[0][0],
       ts_external_scanner_symbol_map,
       tree_sitter_yaml_external_scanner_create,
       tree_sitter_yaml_external_scanner_destroy,

--- a/src/tree_sitter/parser.h
+++ b/src/tree_sitter/parser.h
@@ -102,8 +102,8 @@ struct TSLanguage {
   const uint16_t *small_parse_table;
   const uint32_t *small_parse_table_map;
   const TSParseActionEntry *parse_actions;
-  const char **symbol_names;
-  const char **field_names;
+  const char * const *symbol_names;
+  const char * const *field_names;
   const TSFieldMapSlice *field_map_slices;
   const TSFieldMapEntry *field_map_entries;
   const TSSymbolMetadata *symbol_metadata;
@@ -123,6 +123,7 @@ struct TSLanguage {
     unsigned (*serialize)(void *, char *);
     void (*deserialize)(void *, const char *, unsigned);
   } external_scanner;
+  const TSStateId *primary_state_ids;
 };
 
 /*


### PR DESCRIPTION
Master unlike other ts language repos has bindings/rust in .gitignore so that anybody wanting to use the language has to run `tree-sitter generate`. The generated code in `bindings/rust/build.rs` comments out the code that imports scanner.cc which makes the rust library fail out of the box with linking errors.